### PR TITLE
Improve dashboard class names

### DIFF
--- a/src/app/dashboard/dashboard.component.html
+++ b/src/app/dashboard/dashboard.component.html
@@ -1,41 +1,41 @@
 
-<div class="depth-3-frame-1">
-  <div class="depth-4-frame-02">
-    <div class="depth-5-frame-02">
-      <div class="dashboard2">Dashboard</div>
+<div class="dashboard-container">
+  <div class="dashboard-header">
+    <div class="dashboard-title-container">
+      <div class="dashboard-title">Dashboard</div>
     </div>
   </div>
-  <div class="depth-4-frame-1">
-    <div class="depth-5-frame-03">
+  <div class="metrics-container">
+    <div class="metric-card">
       <div class="depth-6-frame-0">
-        <div class="daily-profit">Daily Profit</div>
+        <div class="metric-label">Daily Profit</div>
       </div>
       <div class="depth-6-frame-12">
-        <div class="_2-500">$2,500</div>
+        <div class="metric-value">$2,500</div>
       </div>
     </div>
-    <div class="depth-5-frame-12">
+    <div class="metric-card">
       <div class="depth-6-frame-0">
-        <div class="total-sales-today">Total Sales Today</div>
+        <div class="metric-label">Total Sales Today</div>
       </div>
       <div class="depth-6-frame-12">
-        <div class="_12-000">$12,000</div>
+        <div class="metric-value">$12,000</div>
       </div>
     </div>
-    <div class="depth-5-frame-2">
+    <div class="metric-card">
       <div class="depth-6-frame-0">
-        <div class="outstanding-bills">Outstanding Bills</div>
+        <div class="metric-label">Outstanding Bills</div>
       </div>
       <div class="depth-6-frame-12">
-        <div class="_3-500">$3,500</div>
+        <div class="metric-value">$3,500</div>
       </div>
     </div>
-    <div class="depth-5-frame-3">
+    <div class="metric-card">
       <div class="depth-6-frame-0">
-        <div class="active-patients">Active Patients</div>
+        <div class="metric-label">Active Patients</div>
       </div>
       <div class="depth-6-frame-12">
-        <div class="_150">150</div>
+        <div class="metric-value">150</div>
       </div>
     </div>
   </div>

--- a/src/app/dashboard/dashboard.component.scss
+++ b/src/app/dashboard/dashboard.component.scss
@@ -877,3 +877,94 @@
   position: relative;
   align-self: stretch;
 }
+.dashboard-container {
+  display: flex;
+  flex-direction: column;
+  gap: 0px;
+  align-items: flex-start;
+  justify-content: flex-start;
+  flex: 1;
+  max-width: 960px;
+  position: relative;
+  overflow: hidden;
+}
+.dashboard-header {
+  padding: 16px;
+  display: flex;
+  flex-direction: row;
+  row-gap: 12px;
+  align-items: flex-start;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  align-content: flex-start;
+  align-self: stretch;
+  flex-shrink: 0;
+  position: relative;
+}
+.dashboard-title-container {
+  display: flex;
+  flex-direction: column;
+  gap: 0px;
+  align-items: flex-start;
+  justify-content: flex-start;
+  flex-shrink: 0;
+  width: 288px;
+  min-width: 288px;
+  position: relative;
+}
+.dashboard-title {
+  color: #0d0f1c;
+  text-align: left;
+  font-family: "Inter-Bold", sans-serif;
+  font-size: 32px;
+  line-height: 40px;
+  font-weight: 700;
+  position: relative;
+  align-self: stretch;
+}
+.metrics-container {
+  padding: 16px;
+  display: flex;
+  flex-direction: row;
+  gap: 16px;
+  align-items: flex-start;
+  justify-content: flex-start;
+  flex-wrap: wrap;
+  align-content: flex-start;
+  align-self: stretch;
+  flex-shrink: 0;
+  position: relative;
+}
+.metric-card {
+  background: #e5e8f5;
+  border-radius: 12px;
+  padding: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  align-items: flex-start;
+  justify-content: flex-start;
+  flex: 1;
+  min-width: 158px;
+  position: relative;
+}
+.metric-label {
+  color: #0d0f1c;
+  text-align: left;
+  font-family: "Inter-Medium", sans-serif;
+  font-size: 16px;
+  line-height: 24px;
+  font-weight: 500;
+  position: relative;
+  align-self: stretch;
+}
+.metric-value {
+  color: #0d0f1c;
+  text-align: left;
+  font-family: "Inter-Bold", sans-serif;
+  font-size: 24px;
+  line-height: 30px;
+  font-weight: 700;
+  position: relative;
+  align-self: stretch;
+}


### PR DESCRIPTION
## Summary
- introduce semantic CSS classes for the dashboard metrics section
- update the dashboard HTML to use the new class names

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848774de7a083238e0ae0dd80631625